### PR TITLE
chore(greenkeeper): ignore typeface-montserrat

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,10 @@
   },
   "greenkeeper": {
     "branchPrefix": "dependency-update-",
-    "label": "dependency-update"
+    "label": "dependency-update",
+    "ignore": [
+      "typeface-montserrat"  
+    ]
   },
   "engines": {
     "node": ">= 4.0.0",


### PR DESCRIPTION
Ignore NPM package typeface-montserrat because it's breaking builds.